### PR TITLE
add ccure session keepalive to scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Backend service for Clearance Assignment functionality.
 | CCURE_CLIENT_NAME\*           | The title for the CCURE client.                                         | University CCURE Client                          |
 | CCURE_CLIENT_ID\*             | The ID for the CCURE client.                                            | 607736e2-b854-594d-bf4a-2c747ded7385             |
 | CCURE_CLIENT_VERSION\*        | The CCURE api version.                                                  | 2.0                                              |
-| RUN_SCHEDULER\*               | Configure whether the scheduler transfers data from MongoDB to CCURE    | True                                             |
 
 
 ## Minimum Database Config

--- a/main.py
+++ b/main.py
@@ -2,7 +2,6 @@
 Backend service for Clearance Assignment functionality.
 """
 
-from os import getenv
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from crud.clearances import router as clearances_router
@@ -51,10 +50,9 @@ def startup_db_client():
     """
     Start the scheduler
     """
-    if getenv("RUN_SCHEDULER") == "True":
-        scheduler = ServiceScheduler()
-        scheduler.start_scheduler()
-        print("Started scheduler")
+    scheduler = ServiceScheduler()
+    scheduler.start_scheduler()
+    print("Started scheduler")
 
 
 @app.on_event("shutdown")

--- a/models/scheduler_framework.py
+++ b/models/scheduler_framework.py
@@ -35,6 +35,7 @@ class ServiceScheduler:
     def one_minute_jobs(self):
         """Add calls to jobs you want to run every minute"""
         SchedulerService.push_to_ccure()
+        SchedulerService.ccure_keepalive()
 
     def start_scheduler(self):
         """Schedule the jobs defined above"""

--- a/models/scheduler_service.py
+++ b/models/scheduler_service.py
@@ -189,6 +189,11 @@ class SchedulerService:
                 {"$set": {"state": "assign-pushed"}}
             )
 
+    @staticmethod
+    def ccure_keepalive():
+        """Keep the Ccure api session active"""
+        CcureApi.session_keepalive()
+
     @classmethod
     def delete_old_assignments(cls):
         """

--- a/util/ccure_api.py
+++ b/util/ccure_api.py
@@ -1,7 +1,6 @@
 """Handle common interactions with the CCURE api"""
 
 import os
-from datetime import datetime, timedelta
 import requests
 from util.singleton import Singleton
 
@@ -9,10 +8,8 @@ from util.singleton import Singleton
 class CcureApi(Singleton):
     """Class for managing interactions with the CCURE api"""
 
-    session_id = None
-    session_id_expiration_time = None
-
     base_url = os.getenv("CCURE_BASE_URL")
+    session_id = None
 
     @classmethod
     def get_session_id(cls):
@@ -20,8 +17,7 @@ class CcureApi(Singleton):
         Get a session_id for a ccure api session
         :return str: the session_id
         """
-        now = datetime.now()
-        if cls.session_id is None or cls.session_id_expiration_time <= now:
+        if cls.session_id is None:
             login_route = "/victorwebservice/api/Authenticate/Login"
             response = requests.post(
                 cls.base_url + login_route,
@@ -35,8 +31,26 @@ class CcureApi(Singleton):
                 timeout=5000
             )
             cls.session_id = response.headers["session-id"]
-            cls.session_id_expiration_time = now + timedelta(seconds=899)
         return cls.session_id
+
+    @classmethod
+    def session_keepalive(cls):
+        """
+        Prevent the Ccure api session from expiring from inactivity.
+        Runs every minute in the scheduler.
+        """
+        keepalive_route = "/victorwebservice/api/v2/session/keepalive"
+        response = requests.post(
+            cls.base_url + keepalive_route,
+            headers={
+                "session-id": cls.get_session_id(),
+                "Access-Control-Expose-Headers": "session-id"
+            },
+            timeout=5000
+        )
+        if response.status_code != 200:
+            print("keepalive:", response.status_code, response.text)
+            CcureApi.session_id = None
 
     @classmethod
     def logout(cls):


### PR DESCRIPTION
## Changes
This replaces the 15-minute expiration time for CCure session ids with a scheduled job to keep a session id valid indefinitely. This should prevent the sporadic outages our users were seeing this week

- add function to hit the ccure `/session/keepalive` endpoint
- add that function to the scheduled every-minute jobs
- remove the option not to run the scheduler
- remove the 15-minute expiration timer for ccure session_id. instead use the same session_id indefinitely.

## How was this tested?

manually, pytest

## How were these changes documented?

removed `RUN_SCHEDULER` var from README
