### PR TITLE
flag revokable clearances

### DIFF
--- a/crud/assignments.py
+++ b/crud/assignments.py
@@ -53,10 +53,7 @@ def get_assignments(response: Response,
     except requests.ConnectTimeout:
         response.status_code = status.HTTP_408_REQUEST_TIMEOUT
         print(f"CCure timeout. Could not get assignments for {campus_id}")
-        return {
-            "assignments": [],
-            "allowed": []
-        }
+        return {"assignments": []}
 
     assigner_email = authorization.get("email", "")
     allowed_clearances = Clearance.get_allowed(assigner_email)

--- a/crud/assignments.py
+++ b/crud/assignments.py
@@ -50,7 +50,6 @@ def get_assignments(response: Response, campus_id: str) -> dict:
         assignments = ClearanceAssignment.get_assignments_by_assignee(campus_id)
     except requests.ConnectTimeout:
         response.status_code = status.HTTP_408_REQUEST_TIMEOUT
-        response.status_code = status.HTTP_408_REQUEST_TIMEOUT
         print(f"CCure timeout. Could not get assignments for {campus_id}")
         return {
             "assignments": [],
@@ -103,7 +102,6 @@ def assign_clearances(response: Response,
         assignment_count = ClearanceAssignment.assign(
             assigner_email, body.assignees, assign_ids)
     except KeyError:
-        response.status_code = status.HTTP_400_BAD_REQUEST
         response.status_code = status.HTTP_400_BAD_REQUEST
         return {
             "changes": 0,

--- a/crud/clearances.py
+++ b/crud/clearances.py
@@ -4,7 +4,7 @@ from typing import Optional
 from fastapi import APIRouter, Response, Depends, status
 import requests
 from auth_checker import AuthChecker
-from middleware.get_authorization import get_authorization
+from util.authorization import get_authorization, user_is_admin
 from models.clearance import Clearance
 
 router = APIRouter()
@@ -14,7 +14,7 @@ router = APIRouter()
             dependencies=[Depends(AuthChecker("clearance_read"))])
 def get_clearances(response: Response,
                    search: Optional[str] = None,
-                   authorization: dict = Depends(get_authorization)) -> dict:
+                   jwt_payload: dict = Depends(get_authorization)) -> dict:
     """
     Search clearances by name or search query and returns details
     about those clearances
@@ -24,14 +24,7 @@ def get_clearances(response: Response,
 
     Returns: A list of Clearance objects matching the search
     """
-    if authorization.get("authorizations", {}).get("root", False) is False:
-        email = authorization.get("email", None)
-        if email is None:
-            response.status_code = status.HTTP_400_BAD_REQUEST
-            return {"detail": "There must be an email address in this token."}
-        clearances = Clearance.get_allowed(email, search)
-
-    else:  # if the user is root
+    if user_is_admin(jwt_payload):
         try:
             clearances = Clearance.get(search)
         except requests.ConnectTimeout:
@@ -39,6 +32,12 @@ def get_clearances(response: Response,
             print(("CCure timeout. "
                    f"Could not get clearances with search {search}"))
             return {"clearance_names": []}
+    else:
+        email = jwt_payload.get("email", None)
+        if email is None:
+            response.status_code = status.HTTP_400_BAD_REQUEST
+            return {"detail": "There must be an email address in this token."}
+        clearances = Clearance.get_allowed(email, search)
 
     response.status_code = status.HTTP_200_OK
     return {"clearance_names": clearances}

--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ from util.ccure_api import CcureApi
 
 
 DESCRIPTION = """Backend service for Clearance Assignment functionality"""
-VERSION = "2023-03-31"
+VERSION = "2023-04-21"
 
 
 def create_app():

--- a/tests/test_assignments_controller.py
+++ b/tests/test_assignments_controller.py
@@ -7,7 +7,6 @@ from fastapi import Response
 from fastapi.testclient import TestClient
 import requests
 from pymongo import MongoClient
-from deepdiff import DeepDiff
 from auth_checker import AuthChecker
 from main import app
 from models.clearance_assignment import ClearanceAssignment
@@ -49,12 +48,12 @@ assigned_clearances = [
     {
         "id": "DECBB54E-4B22-4671-9FA7-F8F370D66A97",
         "name": "Hunt - Turnstiles",
-        "is_allowed": True
+        "can_revoke": True
     },
     {
         "id": "E00D2258-4449-4ACD-B640-8163A4D6CAA2",
         "name": "Library - Faculty Commons",
-        "is_allowed": False
+        "can_revoke": False
     }
 ]
 
@@ -116,7 +115,7 @@ def mock_get_allowed(*_, **__):
     ]
 
 
-def test_get_assignments(monkeypatch):
+def test_get_assignments_as_admin(monkeypatch):
     """
     It should be able to get all active assignments for an individual.
     """
@@ -133,11 +132,20 @@ def test_get_assignments(monkeypatch):
                           headers={"Authorization": "Bearer token"})
     assert response.status_code == 200
 
-    assert DeepDiff(
-        response.json(),
-        {"assignments": assigned_clearances},
-        ignore_order=True
-    ) == {}
+    assert response.json() == {
+        "assignments": [
+            {
+                "id": "DECBB54E-4B22-4671-9FA7-F8F370D66A97",
+                "name": "Hunt - Turnstiles",
+                "can_revoke": True
+            },
+            {
+                "id": "E00D2258-4449-4ACD-B640-8163A4D6CAA2",
+                "name": "Library - Faculty Commons",
+                "can_revoke": True
+            }
+        ]
+    }
 
 
 def test_assign_clearances_as_admin(monkeypatch):
@@ -224,6 +232,29 @@ def test_revoke_clearances_as_admin(monkeypatch):
                            })
     assert response.status_code == 200
     assert response.json() == {"changes": 8}
+
+
+def test_get_assignments_as_liaison(monkeypatch):
+    """
+    It should be able to get all active assignments for an individual.
+    """
+    monkeypatch.setattr(db_connect, "get_clearance_collection",
+                        mock_mongo_client("clearance_assignment"))
+    monkeypatch.setattr(AuthChecker, "check_authorization",
+                        mock_check_authorization)
+    monkeypatch.setattr(CcureApi, "get_clearance_name",
+                        mock_get_clearance_name)
+    monkeypatch.setattr(ClearanceAssignment, "get_assignments_by_assignee",
+                        mock_get_assignments_by_assignee)
+    monkeypatch.setattr(Clearance, "get_allowed", mock_get_allowed)
+    app.dependency_overrides[get_authorization] = (
+        override_get_authorization_liaison)
+
+    response = client.get("/assignments/200103374",
+                          headers={"Authorization": "Bearer token"})
+    assert response.status_code == 200
+    print(response.json())
+    assert response.json() == {"assignments": assigned_clearances}
 
 
 def test_assign_clearances_as_liaison(monkeypatch):

--- a/tests/test_assignments_controller.py
+++ b/tests/test_assignments_controller.py
@@ -13,7 +13,7 @@ from models.clearance_assignment import ClearanceAssignment
 from models.clearance import Clearance
 from util import db_connect
 from util.ccure_api import CcureApi
-from middleware.get_authorization import get_authorization
+from util.authorization import get_authorization
 from tests.override_get_authorization import (
     override_get_authorization, override_get_authorization_liaison)
 

--- a/tests/test_assignments_controller.py
+++ b/tests/test_assignments_controller.py
@@ -48,11 +48,13 @@ clearances = [
 assigned_clearances = [
     {
         "id": "DECBB54E-4B22-4671-9FA7-F8F370D66A97",
-        "name": "Hunt - Turnstiles"
+        "name": "Hunt - Turnstiles",
+        "is_allowed": True
     },
     {
         "id": "E00D2258-4449-4ACD-B640-8163A4D6CAA2",
-        "name": "Library - Faculty Commons"
+        "name": "Library - Faculty Commons",
+        "is_allowed": False
     }
 ]
 
@@ -131,10 +133,11 @@ def test_get_assignments(monkeypatch):
                           headers={"Authorization": "Bearer token"})
     assert response.status_code == 200
 
-    assert DeepDiff(response.json(), {
-        "allowed": assigned_clearances,
-        "assignments": assigned_clearances
-    }, ignore_order=True) == {}
+    assert DeepDiff(
+        response.json(),
+        {"assignments": assigned_clearances},
+        ignore_order=True
+    ) == {}
 
 
 def test_assign_clearances_as_admin(monkeypatch):

--- a/tests/test_assignments_controller.py
+++ b/tests/test_assignments_controller.py
@@ -253,7 +253,6 @@ def test_get_assignments_as_liaison(monkeypatch):
     response = client.get("/assignments/200103374",
                           headers={"Authorization": "Bearer token"})
     assert response.status_code == 200
-    print(response.json())
     assert response.json() == {"assignments": assigned_clearances}
 
 

--- a/tests/test_audit_controller.py
+++ b/tests/test_audit_controller.py
@@ -6,7 +6,7 @@ from pymongo import MongoClient
 from auth_checker import AuthChecker
 from util import db_connect
 from main import app
-from middleware.get_authorization import get_authorization
+from util.authorization import get_authorization
 from tests.override_get_authorization import override_get_authorization
 
 

--- a/tests/test_clearances_controller.py
+++ b/tests/test_clearances_controller.py
@@ -6,7 +6,7 @@ from pymongo import MongoClient
 from auth_checker import AuthChecker
 from main import app
 from models.clearance import Clearance
-from middleware.get_authorization import get_authorization
+from util.authorization import get_authorization
 from tests.override_get_authorization import (
     override_get_authorization, override_get_authorization_liaison)
 from util import db_connect

--- a/tests/test_liaison_controller.py
+++ b/tests/test_liaison_controller.py
@@ -2,7 +2,7 @@
 
 from fastapi.testclient import TestClient
 from auth_checker import AuthChecker
-from middleware.get_authorization import get_authorization
+from util.authorization import get_authorization
 from tests.override_get_authorization import override_get_authorization
 from main import app
 from util.ccure_api import CcureApi

--- a/tests/test_personnel_controller.py
+++ b/tests/test_personnel_controller.py
@@ -2,7 +2,7 @@
 
 from fastapi.testclient import TestClient
 from auth_checker import AuthChecker
-from middleware.get_authorization import get_authorization
+from util.authorization import get_authorization
 from tests.override_get_authorization import override_get_authorization
 from models.personnel import Personnel
 from main import app

--- a/util/authorization.py
+++ b/util/authorization.py
@@ -6,9 +6,12 @@ from fastapi import Header
 
 
 def get_authorization(authorization: str = Header(default=None)):
-    """
-    Extract authorization details out of the token
-    """
+    """Middleware to extract authorization details out of the token"""
     token = authorization.split(" ")[1]
     payload = jwt.decode(token, os.getenv("JWT_SECRET"), ["HS256"])
     return payload
+
+
+def user_is_admin(token: str) -> bool:
+    """Whether the authenticated user has the Admin, or 'root', role"""
+    return token.get("authorizations", {}).get("root", False)


### PR DESCRIPTION
## Changes

- change the shape of the `/assignments/{campus_id}` response to include a boolean `"can_revoke"` field.
- remove the "allowed" top-level field in the json response
- changes to helper functions
    - move `get_authorization`
    - add `user_is_admin`
    - refactor and clean up endpoints using those two functions

## How was this tested?

manually and added pytests

## How were these changes documented?

n/a

## Is the version number updated?

yes
