### PR TITLE
Cmt 326/clearance assignment door groups

### DIFF
--- a/clearance_service/models/audit.py
+++ b/clearance_service/models/audit.py
@@ -54,12 +54,13 @@ class Audit:
         search_filter = filters.PersonnelFilter(
             lookups={"EmailAddress": filters.NFUZZ},
             outer_bool=BooleanOperators.OR,
-            display_properties=[],
+            display_properties=["EmailAddress", "ProperName"],
         )
         people_records = acs.personnel.search(list(people_emails), search_filter)
         names_by_email = {
-            person["EmailAddress"]: person["ProperName"]
+            person.get("EmailAddress"): person.get("ProperName")
             for person in people_records
+            if person.get("EmailAddress")
         }
         result = cls.collection.insert_many(
             [

--- a/clearance_service/models/audit.py
+++ b/clearance_service/models/audit.py
@@ -60,7 +60,7 @@ class Audit:
         names_by_email = {
             person.get("EmailAddress"): person.get("ProperName")
             for person in people_records
-            if person.get("EmailAddress")
+            if person.get("EmailAddress") and person.get("ProperName")
         }
         result = cls.collection.insert_many(
             [
@@ -139,8 +139,8 @@ class Audit:
                 {"$match": match},
                 {"$project": {
                     "_id": 0,
-                    "assigner_name": 1,
-                    "assignee_name": 1,
+                    "assigner_name": {"$ifNull": ["$assigner_name", ""]},
+                    "assignee_name": {"$ifNull": ["$assignee_name", ""]},
                     "action": 1,
                     "timestamp": 1,
                 }},

--- a/clearance_service/models/clearance.py
+++ b/clearance_service/models/clearance.py
@@ -128,9 +128,9 @@ class Clearance:
         return [Clearance(**clearance) for clearance in allowed_clearances]
 
     @staticmethod
-    def get_doors_by_clearance_id(clearance_ids: list[str]):
+    def get_doors_by_clearance_id(clearance_ids: list[str]) -> dict[int, dict[int, Optional[str]]]:
         """
-        Get all doors by clearance ID.
+        Get all doors by clearance ID, including doors granted through a door group.
 
         Parameters:
             clearance_ids: A list of clearance IDs of which to find associated doors.
@@ -177,26 +177,71 @@ class Clearance:
         )
         door_ids = [item["DoorID"] for item in clearance_items if item["DoorID"] is not None]
 
+        # A door group can be shared by more than one of the given clearances, so
+        # each door group maps to a set of clearance IDs, not just one.
+        clearance_ids_by_door_group_id: dict[int, set[int]] = {}
+        for item in clearance_items:
+            if item.get("DoorGroupID"):
+                clearance_ids_by_door_group_id.setdefault(item["DoorGroupID"], set()).add(
+                    item["ClearanceID"]
+                )
+
+        # Resolve door groups into their member doors, and track which clearances
+        # reach each member door via that group.
+        door_ids_by_clearance_id: dict[int, set[int]] = {}
+        if clearance_ids_by_door_group_id:
+            group_member_search_filter = filters.GroupMemberFilter(
+                lookups={"GroupID": filters.NFUZZ},
+                outer_bool=BooleanOperators.OR,
+                display_properties=["TargetObjectID", "GroupID"],
+            )
+            group_members = acs.group_member.search(
+                terms=list(clearance_ids_by_door_group_id),
+                search_filter=group_member_search_filter,
+                timeout=35,
+                page_size=99999,
+            )
+            for member in group_members:
+                for clearance_id in clearance_ids_by_door_group_id.get(member["GroupID"], ()):
+                    door_ids_by_clearance_id.setdefault(clearance_id, set()).add(
+                        member["TargetObjectID"]
+                    )
+            breakpoint()
+
+        all_door_ids = set(door_ids) | {
+            door_id for door_ids_ in door_ids_by_clearance_id.values() for door_id in door_ids_
+        }
+
         # Query door names found in the clearance-to-door relationships.
-        acs_doors = acs.ccure_object.search(
-            object_type=ObjectType.DOOR.complete,
-            search_filter=door_search_filter,
-            terms=door_ids,
-            timeout=35,
-            page_size=99999,
+        acs_doors = (
+            acs.ccure_object.search(
+                object_type=ObjectType.DOOR.complete,
+                search_filter=door_search_filter,
+                terms=list(all_door_ids),
+                timeout=35,
+                page_size=99999,
+            )
+            if all_door_ids
+            else []
         )
         door_names = {}
         for door in acs_doors:
             door_names[door["ObjectID"]] = door["Name"]
 
         # Map door names to the clearance-to-door relationships.
-        clearance_doors = {}
+        clearance_doors: dict[int, dict[int, Optional[str]]] = {}
         for item in clearance_items:
             door_id = item["DoorID"]
             clearance_id = item["ClearanceID"]
             if door_id and door_id in door_names:
-                if clearance_id not in clearance_doors:
-                    clearance_doors[clearance_id] = {}
-                clearance_doors[clearance_id][door_id] = door_names[door_id] or None
+                clearance_doors.setdefault(clearance_id, {})[door_id] = door_names[door_id] or None
+
+        # Map door names found via door groups to the owning clearances.
+        for clearance_id, group_door_ids in door_ids_by_clearance_id.items():
+            for door_id in group_door_ids:
+                if door_id in door_names:
+                    clearance_doors.setdefault(clearance_id, {})[door_id] = (
+                        door_names[door_id] or None
+                    )
 
         return clearance_doors

--- a/clearance_service/models/clearance.py
+++ b/clearance_service/models/clearance.py
@@ -91,7 +91,8 @@ class Clearance:
         )
         clearances = acs.clearance.search(ids, search_filter, page_size=len(ids))
         return [
-            {"id": clearance["ObjectID"], "name": clearance["Name"]} for clearance in clearances
+            {"id": clearance.get("ObjectID"), "name": clearance.get("Name")}
+            for clearance in clearances
         ]
 
     @staticmethod

--- a/clearance_service/models/clearance.py
+++ b/clearance_service/models/clearance.py
@@ -206,7 +206,6 @@ class Clearance:
                     door_ids_by_clearance_id.setdefault(clearance_id, set()).add(
                         member["TargetObjectID"]
                     )
-            breakpoint()
 
         all_door_ids = set(door_ids) | {
             door_id for door_ids_ in door_ids_by_clearance_id.values() for door_id in door_ids_

--- a/clearance_service/models/personnel.py
+++ b/clearance_service/models/personnel.py
@@ -215,7 +215,9 @@ class Personnel:
         if person_records:
             personnel = []
             for record in person_records:
-                person_data = {prop_name: record[prop_name] for prop_name in display_properties}
+                person_data = {
+                    prop_name: record.get(prop_name) for prop_name in display_properties
+                }
                 personnel.append(Personnel(person_data))
                 # NOTE this is a different definition of 'active' than in _find_one
             return personnel

--- a/clearance_service/models/personnel.py
+++ b/clearance_service/models/personnel.py
@@ -131,7 +131,7 @@ class Personnel:
 
         if person_records:
             person_record = {
-                property: person_records[0][property]
+                property: person_records[0].get(property)
                 for property in search_filter.display_properties
             }
             person = Personnel(person_record)
@@ -171,6 +171,7 @@ class Personnel:
         search_filter = filters.PersonnelFilter(
             lookups={"EmailAddress": filters.NFUZZ},
             display_properties=list(set([
+                "ObjectID",
                 "FirstName",
                 "MiddleName",
                 "LastName",

--- a/clearance_service/tests/test_assignments_controller.py
+++ b/clearance_service/tests/test_assignments_controller.py
@@ -251,6 +251,72 @@ def mock_get_acs_doors(*_, **__):
     ]
 
 
+def mock_get_clearance_items_with_door_group(*_, **__):
+    """
+    Mock clearance items where clearance 5000 has a direct door plus a door group,
+    and clearance 5001 shares that same door group.
+    """
+    return [
+        {
+            "*state": 1,
+            "ClassType": "SoftwareHouse.NextGen.Common.SecurityObjects.ClearanceItem",
+            "GUID": "9c3bd102-a49f-4b8f-b9fa-03e483f97a3f",
+            "ClearanceID": 5000,
+            "DoorID": 3000,
+            "ElevatorID": None,
+            "ScheduleID": 2,
+            "DoorGroupID": None,
+            "ElevatorGroupID": None,
+            "*appServer": "VRB-C9K-02",
+            "ObjectID": 5003,
+            "*PK": ["ObjectID"],
+        },
+        {
+            "*state": 1,
+            "ClassType": "SoftwareHouse.NextGen.Common.SecurityObjects.ClearanceItem",
+            "GUID": "c2973f52-13fa-441c-a6fb-6acbeace3585",
+            "ClearanceID": 5000,
+            "DoorID": None,
+            "ElevatorID": None,
+            "ScheduleID": 3,
+            "DoorGroupID": 9000,
+            "ElevatorGroupID": None,
+            "*appServer": "VRB-C9K-02",
+            "ObjectID": 5004,
+            "*PK": ["ObjectID"],
+        },
+        {
+            "*state": 1,
+            "ClassType": "SoftwareHouse.NextGen.Common.SecurityObjects.ClearanceItem",
+            "GUID": "d3973f52-13fa-441c-a6fb-6acbeace3586",
+            "ClearanceID": 5001,
+            "DoorID": None,
+            "ElevatorID": None,
+            "ScheduleID": 3,
+            "DoorGroupID": 9000,
+            "ElevatorGroupID": None,
+            "*appServer": "VRB-C9K-02",
+            "ObjectID": 5005,
+            "*PK": ["ObjectID"],
+        },
+    ]
+
+
+def mock_get_group_members(*_, **__):
+    """Mock group members for door group 9000, containing door 3001."""
+    return [
+        {
+            "*state": 1,
+            "ClassType": "SoftwareHouse.NextGen.Common.SecurityObjects.GroupMember",
+            "GroupID": 9000,
+            "TargetObjectID": 3001,
+            "*appServer": "VRB-C9K-02",
+            "ObjectID": 9100,
+            "*PK": ["ObjectID"],
+        }
+    ]
+
+
 def mock_assign_clearances(*_, **__):
     """Mock a clearance assignment in acs."""
     return
@@ -264,13 +330,15 @@ def mock_get_assigned_clearances(*_, **__):
 def mock_find_by_email(*_, **__):
     """Mock Personnel.search_by_email"""
     return [
-        Personnel({
-            "FirstName": "John",
-            "MiddleName": None,
-            "LastName": "Champion",
-            "EmailAddress": "person2@email.com",
-            "ObjectID": 5001,
-        }),
+        Personnel(
+            {
+                "FirstName": "John",
+                "MiddleName": None,
+                "LastName": "Champion",
+                "EmailAddress": "person2@email.com",
+                "ObjectID": 5001,
+            }
+        ),
     ]
 
 
@@ -302,7 +370,9 @@ def test_error_get_assignments(db, fake_auth, monkeypatch):
     monkeypatch.setattr(acs.clearance, "get_property", mock_get_clearance_name)
     monkeypatch.setattr(ScheduledAction, "get_clearances_by_assignee", mock_error)
 
-    response = client.get("/assignments/person2@email.com", headers={"Authorization": "Bearer token"})
+    response = client.get(
+        "/assignments/person2@email.com", headers={"Authorization": "Bearer token"}
+    )
     assert response.status_code == 400
 
 
@@ -314,7 +384,9 @@ def test_get_assignments_as_admin(db, fake_auth, monkeypatch):
     monkeypatch.setattr(
         ScheduledAction, "get_clearances_by_assignee", mock_get_clearances_by_assignee
     )
-    response = client.get("/assignments/person2@email.com", headers={"Authorization": "Bearer token"})
+    response = client.get(
+        "/assignments/person2@email.com", headers={"Authorization": "Bearer token"}
+    )
     assert response.status_code == 200
     assert response.json() == {
         "assignments": [
@@ -358,6 +430,45 @@ def test_get_assignments_with_doors(db, fake_auth, monkeypatch):
                 },
             },
             {"id": 5001, "name": "Library - Faculty Commons", "can_revoke": True, "doors": {}},
+        ]
+    }
+
+
+def test_get_assignments_with_doors_via_door_group(db, fake_auth, monkeypatch):
+    """
+    It should include doors granted through a door group, attributing the group's
+    doors to every clearance that references it, even when the group is shared.
+    """
+    monkeypatch.setattr(acs.clearance, "get_property", mock_get_clearance_name)
+    monkeypatch.setattr(
+        ScheduledAction, "get_clearances_by_assignee", mock_get_clearances_by_assignee
+    )
+    monkeypatch.setattr(acs.clearance_item, "search", mock_get_clearance_items_with_door_group)
+    monkeypatch.setattr(acs.group_member, "search", mock_get_group_members)
+    monkeypatch.setattr(acs.ccure_object, "search", mock_get_acs_doors)
+    response = client.get(
+        "/assignments/person2@email.com?get_doors=True", headers={"Authorization": "Bearer token"}
+    )
+    assert response.status_code == 200
+    assert response.json() == {
+        "assignments": [
+            {
+                "id": 5000,
+                "name": "Hunt - Turnstiles",
+                "can_revoke": True,
+                "doors": {
+                    "3000": "VRB-B-B103C-Test Door 1234",
+                    "3001": "VRB-B-B103C-Test Door 5678",
+                },
+            },
+            {
+                "id": 5001,
+                "name": "Library - Faculty Commons",
+                "can_revoke": True,
+                "doors": {
+                    "3001": "VRB-B-B103C-Test Door 5678",
+                },
+            },
         ]
     }
 
@@ -537,7 +648,9 @@ def test_get_assignments_as_liaison(db, fake_auth, monkeypatch):
     monkeypatch.setattr(Clearance, "get_allowed", mock_get_allowed)
     app.dependency_overrides[get_authorization] = override_get_authorization_liaison
 
-    response = client.get("/assignments/person2@email.com", headers={"Authorization": "Bearer token"})
+    response = client.get(
+        "/assignments/person2@email.com", headers={"Authorization": "Bearer token"}
+    )
     assert response.status_code == 200
     assert response.json() == {"assignments": assigned_clearances}
 

--- a/clearance_service/tests/test_audit_controller.py
+++ b/clearance_service/tests/test_audit_controller.py
@@ -44,6 +44,37 @@ def test_search_actions(db, fake_auth):
     assert len(response.json()) == 1
 
 
+def test_search_actions_with_null_names(db, fake_auth):
+    """Records with null assigner_name/assignee_name (e.g. from before names were
+    resolved, or an unmatched CCure lookup) should not break the endpoint"""
+
+    ca_collection = db.audit
+
+    audit_records = [
+        {
+            "_id": bson.ObjectId(),
+            "assigner_name": None,
+            "assignee_name": None,
+            "assigner": "",
+            "assignee": "",
+            "action": "",
+            "clearance_id": None,
+            "clearance_name": "",
+            "timestamp": datetime.now(),
+            "message": "test_message",
+        }
+    ]
+
+    ca_collection.insert_many(audit_records)
+
+    response = client.get("/audit", headers={"Authorization": "Bearer token"})
+    assert response.status_code == 200
+    records = response.json()["records"]
+    assert len(records) == 1
+    assert records[0]["assigner_name"] == ""
+    assert records[0]["assignee_name"] == ""
+
+
 def test_search_actions_by_assigner_pagination(db, fake_auth):
     """Test the search_actions_by_assigner endpoint with pagination"""
 


### PR DESCRIPTION
## Changes
In the `/assignments/{email}` route, if get_doors is enabled, return doors in door groups in addition to doors tied directly to clearances.
